### PR TITLE
fix(keys): build talos_signing_key.pem with key + cert, newline-safe

### DIFF
--- a/scripts/setup-keys.sh
+++ b/scripts/setup-keys.sh
@@ -78,7 +78,16 @@ if [[ -d "${KERNEL_CERTS_DIR}" ]]; then
   # The kernel's certs/Makefile auto-generates "signing_key.pem" on every fresh build,
   # overwriting any copy we place there. "talos_signing_key.pem" has no auto-gen rule,
   # so make never touches it and our key is always embedded in the kernel.
-  cp "${KEY_PEM}"  "${KERNEL_CERTS_DIR}/talos_signing_key.pem"
+  # CONFIG_MODULE_SIG_KEY must name a PEM holding BOTH the private key and its
+  # certificate: certs/Makefile builds signing_key.x509 by running extract-cert
+  # against this very file, so a key-only PEM fails the build with
+  # "PEM routines::no start line" once the kernel reaches the certs/ target.
+  # A plain `cat` is not safe here: CI restores the key from a GitHub secret
+  # with `printf '%s'`, which leaves no trailing newline, so the two files
+  # fuse into "-----END PRIVATE KEY----------BEGIN CERTIFICATE-----" and the
+  # build fails with "PEM routines::bad end line". Emit an explicit separator.
+  { cat "${KEY_PEM}"; printf '\n'; cat "${KEY_X509}"; } \
+    > "${KERNEL_CERTS_DIR}/talos_signing_key.pem"
   cp "${KEY_X509}" "${KERNEL_CERTS_DIR}/talos_signing_key.x509"
   info "Keys copied to ${KERNEL_CERTS_DIR}/talos_signing_key.{pem,x509}"
 else


### PR DESCRIPTION
`CONFIG_MODULE_SIG_KEY` names a PEM file that the kernel's `certs/Makefile` feeds to `extract-cert` in order to produce `signing_key.x509`:

```make
$(obj)/signing_key.x509: $(filter-out $(PKCS11_URI),$(CONFIG_MODULE_SIG_KEY)) $(obj)/extract-cert FORCE
        $(call if_changed,extract_certs)
```

`setup-keys.sh` copies only the **private key** to `certs/talos_signing_key.pem`, so that file contains no `BEGIN CERTIFICATE` block and every kernel build fails at the `certs/` target, roughly 47 s in:

```
CERT    certs/signing_key.x509
At main.c:174:
- SSL error:0480006C:PEM routines::no start line: crypto/pem/pem_lib.c:794
extract-cert: certs/talos_signing_key.pem
make[3]: *** [certs/Makefile:74: certs/signing_key.x509] Error 1
```

Concatenating the certificate in also has to be newline-safe. CI restores the key from a GitHub secret with `printf '%s'`, which leaves no trailing newline, so a plain `cat` fuses the two blocks into a single malformed line and swaps one failure for another:

```
-----END PRIVATE KEY----------BEGIN CERTIFICATE-----
- SSL error:04800066:PEM routines::bad end line: crypto/pem/pem_lib.c:901
```

This PR emits an explicit separator so the result is correct whether or not the inputs end in a newline.

**Verified** against all four combinations — key-only and key+cert secret values, each with and without a trailing newline — plus a full release build that now gets past `certs/`, compiles the kernel, and completes extension and UKI assembly. The private key remains readable from the same file, so the `sign-file` path is unaffected.

Note this failure cannot occur on a fresh local build where the kernel auto-generates its own `certs/signing_key.pem`; it only appears once a key is supplied, which is why CI has never gotten past it.

Found while building this repository's images from a fork. Other defects also block publishing end-to-end; they are in separate PRs to keep review independent.