### PR TITLE
fix: keep the v prefix on TALOS_VERSION, and move PKGS_COMMIT with it

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -64,8 +64,7 @@
       "managerFilePatterns": ["/^scripts/common\\.sh$/"],
       "matchStrings": ["TALOS_VERSION=\"\\$\\{TALOS_VERSION:-(?<currentValue>[^}\"]+)\\}\""],
       "depNameTemplate": "siderolabs/talos",
-      "datasourceTemplate": "github-releases",
-      "extractVersionTemplate": "^v?(?<version>.*)$"
+      "datasourceTemplate": "github-releases"
     },
     {
       "customType": "regex",

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -15,10 +15,10 @@ CACHE_REGISTRY="${CACHE_REGISTRY:-}"  # set to ghcr.io/<owner>/build-cache in CI
 
 # ── Talos version ────────────────────────────────────────────────────────────
 # Tracked by Renovate — update-talos.yaml is no longer used (removed).
-TALOS_VERSION="${TALOS_VERSION:-1.13.8}"
+TALOS_VERSION="${TALOS_VERSION:-v1.13.8}"
 
 # ── siderolabs/pkgs pin (derived from TALOS_VERSION) ─────────────────────────
-PKGS_COMMIT="${PKGS_COMMIT:-f3829f74}"   # latest commit on release-1.13 (2026-04-24, kernel 6.18.24)
+PKGS_COMMIT="${PKGS_COMMIT:-f677246a}"  # matches Talos v1.13.8 (PKGS v1.13.0-55-gf677246, kernel 6.18.42)
 PKGS_BRANCH="${PKGS_BRANCH:-release-$(echo "${TALOS_VERSION}" | sed 's/^v//' | cut -d. -f1,2)}"
 
 # ── Kernel version — derived automatically from siderolabs/pkgs ──────────────


### PR DESCRIPTION
`TALOS_VERSION` is consumed as an image tag (`siderolabs/installer`, `siderolabs/imager`) and as a GitHub release tag — all of which are `v`-prefixed. `common.sh` already strips the prefix defensively where a bare number is needed:

```sh
PKGS_BRANCH="${PKGS_BRANCH:-release-$(echo "${TALOS_VERSION}" | sed 's/^v//' | cut -d. -f1,2)}"
```

Renovate's `extractVersionTemplate` (`^v?(?<version>.*)$`) discards that prefix on every automated bump, so the installer pull 404s:

```
#3 ERROR: ghcr.io/siderolabs/installer:1.13.8: not found
```

`ghcr.io/siderolabs/installer:1.13.8` returns HTTP 404; only `v1.13.8` exists (HTTP 200). Same for `siderolabs/imager`.

The history shows the pattern clearly — humans write the prefix, Renovate removes it:

| Commit | Author | Value |
| --- | --- | --- |
| `5d1eb56` | mrmoor | `v1.12.6` |
| `d1a7a27` | renovate[bot] | `1.12.7` |
| `438dd5f` | Alexander Schwankner | `v1.13.0` |
| `877807a` | renovate[bot] | `1.13.8` |

Dropping `extractVersionTemplate` stops it recurring; the datasource already returns the tag in the form the scripts want.

### Why `PKGS_COMMIT` moves in the same commit

The two are coupled and cannot be split. With `TALOS_VERSION=v1.13.8` the imager ships kernel **6.18.42**, while extensions built from `f3829f74` provide modules for **6.18.24**, so UKI assembly fails:

```
copying kernel modules from …/extensions/0/rootfs/usr/lib/modules failed:
  stat …/usr/lib/modules/6.18.42-talos: no such file or directory
```

`f677246a` is the pkgs commit Talos v1.13.8 itself pins (`PKGS ?= v1.13.0-55-gf677246`). Fixing the prefix without this would simply trade one build failure foranother, ~90 minutes later.

The underlying problem — that `PKGS_COMMIT` is described as "derived from `TALOS_VERSION`" but is actually hardcoded, so Renovate desyncs them on every bump — is filed separately, since it needs a design decision rather than a value change.

### Side effect

This also fixes `check-talos.yaml`. It compares `TALOS_VERSION` from `common.sh` against the API's `tag_name`, so with the prefix stripped the equality test never matched and it reported an update against itself. With the prefix restored, `v1.13.8` == `v1.13.8` and it correctly reports up to date.

**Verified:** a full release build from these values succeeds end to end, and the resulting installer boots a Jetson Orin NX with the nvgpu stack loaded, `/dev/dri/renderD128` present, and CUDA inference running at parity with the previous 6.18.24 build. The OE4T modules compiled against 6.18.42 without changes.