### PR TITLE
fix(build): derive PKGS_COMMIT from TALOS_VERSION instead of hardcoding it

### DIFF
--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -17,8 +17,18 @@ CACHE_REGISTRY="${CACHE_REGISTRY:-}"  # set to ghcr.io/<owner>/build-cache in CI
 # Tracked by Renovate — update-talos.yaml is no longer used (removed).
 TALOS_VERSION="${TALOS_VERSION:-v1.13.8}"
 
-# ── siderolabs/pkgs pin (derived from TALOS_VERSION) ─────────────────────────
-PKGS_COMMIT="${PKGS_COMMIT:-f677246a}"  # matches Talos v1.13.8 (PKGS v1.13.0-55-gf677246, kernel 6.18.42)
+# ── siderolabs/pkgs pin — derived from TALOS_VERSION ─────────────────────────
+# Talos records the exact pkgs commit it was built against in its own
+# Makefile, as `PKGS ?= <git-describe>-g<sha>`. Reading it here means the pin
+# can never desync from TALOS_VERSION again: whatever Renovate bumps it to,
+# PKGS_COMMIT (and KERNEL_VERSION below) follows automatically.
+# Override via env: PKGS_COMMIT=<sha> source scripts/common.sh
+if [ -z "${PKGS_COMMIT:-}" ]; then
+  PKGS_COMMIT="$(curl -fsSL \
+    "https://raw.githubusercontent.com/siderolabs/talos/${TALOS_VERSION}/Makefile" \
+    | grep '^PKGS ?=' | sed -E 's/^PKGS \?= .*-g([0-9a-f]+)$/\1/')"
+  [ -z "${PKGS_COMMIT}" ] && { echo "[ERROR] Could not derive PKGS_COMMIT from Talos ${TALOS_VERSION} Makefile" >&2; exit 1; }
+fi
 PKGS_BRANCH="${PKGS_BRANCH:-release-$(echo "${TALOS_VERSION}" | sed 's/^v//' | cut -d. -f1,2)}"
 
 # ── Kernel version — derived automatically from siderolabs/pkgs ──────────────


### PR DESCRIPTION
Closes #41.

`PKGS_COMMIT` was hardcoded despite the comment claiming it was "derived from `TALOS_VERSION`". Renovate only tracks `TALOS_VERSION`, so every automated Talos bump silently desynced the two — the mismatch only surfaced ~90 minutes into a build when UKI assembly failed to find the expected kernel module path.

Talos records the exact pkgs commit it was built against in its own Makefile (`PKGS ?= <describe>-g<sha>`). Read it from there instead, the same way `KERNEL_VERSION` is already derived from the pinned `PKGS_COMMIT`.

**Verified before opening this PR:**
- v1.13.8 → derives `f677246` (kernel 6.18.42), matching the value #40 just hardcoded
- v1.13.5 → derives `6b315f7` (kernel 6.18.36), confirming this isn't a coincidence specific to the current pin
- `PKGS_COMMIT=<sha>` env override still works and skips the network call
- Full CI build on this branch (https://github.com/schwankner/talos-jetson-orin/actions/runs/32270105542): correctly resolved `f677246` under Ubuntu/GNU sed, cloned pkgs, built kernel 6.18.42, pushed extensions