### PR TITLE
chore(build): bump Talos to v1.13.9

### DIFF
--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -15,7 +15,7 @@ CACHE_REGISTRY="${CACHE_REGISTRY:-}"  # set to ghcr.io/<owner>/build-cache in CI
 
 # ── Talos version ────────────────────────────────────────────────────────────
 # Tracked by Renovate — update-talos.yaml is no longer used (removed).
-TALOS_VERSION="${TALOS_VERSION:-v1.13.8}"
+TALOS_VERSION="${TALOS_VERSION:-v1.13.9}"
 
 # ── siderolabs/pkgs pin — derived from TALOS_VERSION ─────────────────────────
 # Talos records the exact pkgs commit it was built against in its own


### PR DESCRIPTION
Closes #42.

Kernel 6.18.44, Kubernetes 1.36.3, containerd 2.2.7. No breaking changes affecting the GPU/DRM stack per the [release notes](https://github.com/siderolabs/talos/releases/tag/v1.13.9).

`PKGS_COMMIT` isn't part of this diff since #45: it now derives automatically from `TALOS_VERSION` (resolves to `f541ca4`, matching the release's own pkgs pin `v1.13.0-60-gf541ca4`).

**Verified with a real build** on this branch (https://github.com/schwankner/talos-jetson-orin/actions/runs/32299621772): kernel 6.18.44 compiled, and the extension pushed as `nvidia-tegra-nvgpu:5.11.1-drm-noshim-6.18.44-talos`.