### PR TITLE
chore(build): bump Talos to v1.13.10

### DIFF
--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -15,7 +15,7 @@ CACHE_REGISTRY="${CACHE_REGISTRY:-}"  # set to ghcr.io/<owner>/build-cache in CI
 
 # ── Talos version ────────────────────────────────────────────────────────────
 # Tracked by Renovate — update-talos.yaml is no longer used (removed).
-TALOS_VERSION="${TALOS_VERSION:-v1.13.9}"
+TALOS_VERSION="${TALOS_VERSION:-v1.13.10}"
 
 # ── siderolabs/pkgs pin — derived from TALOS_VERSION ─────────────────────────
 # Talos records the exact pkgs commit it was built against in its own


### PR DESCRIPTION
Kernel 6.18.48, plus DHCP library update, kubelet client-cert handling hardening, CSI SELinux mount fix and other security/robustness fixes from the [release notes](https://github.com/siderolabs/talos/releases/tag/v1.13.10). No breaking changes affecting the GPU/DRM stack.

This release was never surfaced by `check-talos.yaml`: it was published the same day as v1.14.0, so `/releases/latest` had already moved past it before the next daily run (fixed by a84d22f — the check now compares by real semver instead of publish date).

`PKGS_COMMIT` isn't part of this diff since #45: it derives automatically from `TALOS_VERSION` (resolves to `9b044c5`, matching the release's own pkgs pin `v1.13.0-65-g9b044c5`).

**Verified with a real build** on this branch (https://github.com/schwankner/talos-jetson-orin/actions/runs/33966059399): kernel 6.18.48 compiled, and the extension pushed as `nvidia-tegra-nvgpu:5.11.1-drm-noshim-6.18.48-talos`.