### PR TITLE
chore(build): migrate to Talos v1.14.0 (installer-base instead of the unpublished installer image)

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -1062,3 +1062,60 @@ apply it via `--config-patch` during `talosctl gen config`.
 
 **Status**: ✅ **FIXED** — `machine.kernel.modules` added to reference `controlplane.yaml`
 and `machine-patch-gpu.yaml`. README Installation section documents `--config-patch` usage.
+
+## Bug 22 — `ghcr.io/siderolabs/installer` No Longer Published (Talos ≥ 1.14)
+
+**Symptom**: Bumping `TALOS_VERSION` to `v1.14.0` breaks `scripts/build-extensions.sh` in
+Step 5 before any of our own code runs:
+
+```
+FROM ghcr.io/siderolabs/installer:v1.14.0
+→ manifest unknown (HTTP 404)
+```
+
+`ghcr.io/siderolabs/installer:v1.13.10` still resolves (200); `v1.14.0` does not.
+
+**Root cause**: Sidero stopped publishing the full `installer` image with Talos 1.14
+(siderolabs/talos#13138, implemented in #13202, listed under "Default Installer Image" in the
+v1.14.0 release notes). Released installers are now served by the Image Factory
+(`factory.talos.dev/metal-installer/<schematic>:<version>`). That is no replacement for this
+project: the Image Factory only accepts *official* extensions by name and has no mechanism to
+inject a custom kernel — and a custom-signed kernel is exactly what the OE4T modules require.
+
+**Fix**: Base `custom-installer` on `ghcr.io/siderolabs/installer-base` instead. It is still
+published (it is in the v1.14.0 "Images" list) and contains only the rootfs plus
+`/usr/bin/installer`, no kernel. This is not a workaround but the upstream default: since
+Talos 1.11 the imager itself falls back to `installer-base:<version>` as `baseInstaller`
+(`pkg/imager/profile/input.go`, `SupportsUnifiedInstaller`), and `make installer` in the Talos
+repo passes it as `--base-installer-image`.
+
+Why the kernel is still ours: the imager's `installer` output (`pkg/imager/out.go`,
+`outInstaller`) takes the `baseInstaller` layers and appends an artifacts layer with the kernel
+taken from its *own* `Input.Kernel.Path` — i.e. from `custom-imager`, which carries our signed
+`vmlinuz`. The `vmlinuz.efi` we `COPY` into `custom-installer` is only a transport artifact for
+`build-uki.sh`; if `installer-base` + our `COPY` layer happen to be exactly two layers, the
+imager even drops the second one (`len(baseLayers) == 2` quirk) and re-adds a fresh one.
+
+`ghcr.io/siderolabs/imager` is unaffected and still published, so `build-uki.sh` and
+`release.yaml` need no change. The v1alpha1 machine-config fields we use (`.machine.kernel`,
+`.machine.install`, `.machine.files`) are deprecated in 1.14 in favour of `KernelModuleConfig`,
+`UnattendedInstallConfig` and `EtcFileConfig`, but are "moved out", not removed, and keep
+working — migrating them is a separate follow-up.
+
+## Bug 23 — `check-talos.yaml` Compares Against the Most Recently *Published* Release, Not the Highest
+
+**Symptom**: The daily check opened issue #52 "New Talos release: v1.12.12 (current: v1.13.9)"
+— a *lower* version reported as an update. At the same time `v1.13.10` (a real patch on our own
+line) was never reported at all.
+
+**Root cause**: The workflow used `GET /repos/siderolabs/talos/releases/latest`, which returns
+whichever stable release was published most recently — not the highest version. Sidero maintains
+several release lines in parallel (1.12.x, 1.13.x, 1.14.x). On 2026-09-03/04 the publish order
+was `v1.14.0` → `v1.13.10` → `v1.12.12`, so by the next daily run "latest" had already moved past
+`v1.13.10` to the older-line patch `v1.12.12`.
+
+**Fix** (`a84d22f`): fetch *all* stable releases (`gh api ... --paginate`, filter
+`draft == false and prerelease == false`) and pick the highest by a numeric field sort on
+`major.minor.patch` (`sort -t. -k1,1n -k2,2n -k3,3n`). A first attempt embedded a multi-line
+Python snippet inside the YAML `run: |` block; unindented lines inside a block scalar break the
+YAML, so the pure `sort`-based version was used instead.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Talos Linux on NVIDIA Jetson Orin — GPU Compute / CUDA
 
-[![Talos](https://img.shields.io/badge/Talos-v1.13.0-blue)](https://github.com/siderolabs/talos/releases/tag/v1.13.0)
-[![Kubernetes](https://img.shields.io/badge/Kubernetes-v1.35.2-blue)](https://kubernetes.io/)
-[![Kernel](https://img.shields.io/badge/kernel-6.18.24--talos-orange)](https://github.com/siderolabs/pkgs)
+[![Talos](https://img.shields.io/badge/Talos-v1.14.0-blue)](https://github.com/siderolabs/talos/releases/tag/v1.14.0)
+[![Kubernetes](https://img.shields.io/badge/Kubernetes-v1.37.0-blue)](https://kubernetes.io/)
+[![Kernel](https://img.shields.io/badge/kernel-6.18.48--talos-orange)](https://github.com/siderolabs/pkgs)
 [![nvgpu](https://img.shields.io/badge/nvgpu-5.11.1--drm-green)](https://github.com/OE4T/linux-nvgpu)
 [![License: MPL 2.0](https://img.shields.io/badge/License-MPL_2.0-brightgreen.svg)](LICENSE)
 [![Build](https://github.com/schwankner/talos-jetson-orin/actions/workflows/release.yaml/badge.svg)](https://github.com/schwankner/talos-jetson-orin/actions/workflows/release.yaml)
@@ -60,7 +60,7 @@ No `privileged: true`, no manual `/dev` bind-mounts in pod specs.
 - Jetson Orin module (AGX Orin, Orin NX 16/8 GB, Orin Nano 8/4 GB)
 - EDK2 UEFI in SPI flash (factory default on all Orin modules)
 - USB stick (16 GB+) for flashing
-- `talosctl` v1.13.0: https://github.com/siderolabs/talos/releases/tag/v1.13.0
+- `talosctl` v1.14.0: https://github.com/siderolabs/talos/releases/tag/v1.14.0
 
 > **Xavier, TX2, classic Nano**: different GPU architecture — not supported.
 
@@ -222,8 +222,17 @@ source scripts/common.sh
 
 **Custom installer image** (for `talosctl upgrade`):
 ```
-ghcr.io/schwankner/custom-installer:v1.13.0-6.18.24-nvgpu5.11.1-drm-noshim
+ghcr.io/schwankner/custom-installer:v1.14.0-6.18.48-nvgpu5.11.1-drm-noshim
 ```
+
+> **Talos ≥ 1.14:** `ghcr.io/siderolabs/installer` is no longer published — released installers
+> are served by the [Image Factory](https://factory.talos.dev), which cannot take a custom kernel.
+> The build therefore uses `ghcr.io/siderolabs/installer-base` as the installer base and lets the
+> imager add the custom-signed kernel, which is the same default Talos' own imager uses since 1.11.
+> The v1alpha1 fields `.machine.kernel`, `.machine.install` and `.machine.files` used in
+> `manifests/talos/` are deprecated in 1.14 in favour of `KernelModuleConfig`,
+> `UnattendedInstallConfig` and `EtcFileConfig` documents, but still work unchanged; migrating them
+> is tracked separately.
 
 ---
 
@@ -231,9 +240,9 @@ ghcr.io/schwankner/custom-installer:v1.13.0-6.18.24-nvgpu5.11.1-drm-noshim
 
 | Component | Version |
 |---|---|
-| Talos Linux | v1.13.0 |
-| Kubernetes | v1.35.2 |
-| Linux kernel | 6.18.24-talos |
+| Talos Linux | v1.14.0 |
+| Kubernetes | v1.37.0 |
+| Linux kernel | 6.18.48-talos |
 | nvidia-tegra-nvgpu extension | 5.11.1-drm-noshim |
 | JetPack libs (userspace) | r36.5.0 |
 | Ollama | 0.20.5 |
@@ -294,7 +303,7 @@ This was the root cause before the DRM fix was applied. With the current extensi
 (`nvgpu5.11.1-drm-noshim`), this should not occur. Verify the correct extension is loaded:
 ```bash
 talosctl get extensions --nodes <jetson-ip> | grep nvgpu
-# Expected: nvidia-tegra-nvgpu  5.11.1-drm-noshim-6.18.24-talos
+# Expected: nvidia-tegra-nvgpu  5.11.1-drm-noshim-6.18.48-talos
 ```
 
 ---

--- a/manifests/talos/controlplane.yaml.example
+++ b/manifests/talos/controlplane.yaml.example
@@ -77,9 +77,9 @@ machine:
     # Used to provide instructions for installations.
     install:
         disk: /dev/nvme0n1 # The disk used for installations.
-        image: ghcr.io/schwankner/custom-installer:v1.12.6-6.18.18 # Custom installer with clang kernel + NVIDIA extensions.
+        image: ghcr.io/schwankner/custom-installer:v1.14.0-6.18.48-nvgpu5.11.1-drm-noshim # Custom installer with clang kernel + NVIDIA extensions.
         # Local registry fallback (when ghcr.io package is not yet public or CI hasn't run):
-        # image: 10.0.10.24:5001/custom-installer:v1.12.6-6.18.18
+        # image: 10.0.10.24:5001/custom-installer:v1.14.0-6.18.48-nvgpu5.11.1-drm-noshim
         wipe: true # Wipe the installation disk to ensure clean state.
         # grubUseUKICmdline: MUST NOT be set on arm64/UKI-based installs!
         # This flag is for legacy x86 GRUB only. On Jetson Orin NX (arm64), Talos uses

--- a/manifests/talos/machine-patch.yaml
+++ b/manifests/talos/machine-patch.yaml
@@ -18,7 +18,7 @@
 machine:
   install:
     disk: /dev/nvme0n1
-    image: ghcr.io/schwankner/custom-installer:v1.13.0-6.18.24-nvgpu5.11.1-drm-noshim
+    image: ghcr.io/schwankner/custom-installer:v1.14.0-6.18.48-nvgpu5.11.1-drm-noshim
     wipe: false
   kernel:
     modules:

--- a/nvidia-tegra-nvgpu/pkg.yaml
+++ b/nvidia-tegra-nvgpu/pkg.yaml
@@ -326,7 +326,7 @@ steps:
           ${NVIDIA_OOT}/drivers/gpu/drm/tegra/drm.h
         # Replace conftest probe macros with LINUX_VERSION_CODE guards.
         # Conftest probes are unreliable with Clang/-Werror; explicit version
-        # checks are deterministic. Target kernel: 6.18.24-talos.
+        # checks are deterministic. Target kernel: 6.18.x-talos (guards are range-based).
         TEGRA_DRM=${NVIDIA_OOT}/drivers/gpu/drm/tegra
         # Generic substitution helper for kernel-version-gated PRESENT/ARG macros
         # Format: macro|kernel_version

--- a/scripts/build-extensions.sh
+++ b/scripts/build-extensions.sh
@@ -11,7 +11,7 @@
 #                           and as signing_key.pem to nvidia-tegra-nvgpu/
 #   kernel-build          → embeds talos_signing_key.pem (make never auto-regenerates it)
 #   nvidia-tegra-nvgpu    → signs all .ko with signing_key.pem from /pkg/
-#   custom-installer      → gets the vmlinuz from this exact kernel-build
+#   custom-installer      → installer-base + the vmlinuz from this exact kernel-build
 #   → UKI kernel and ALL extension modules ALWAYS share the same signing key
 #
 # Usage:
@@ -21,7 +21,7 @@
 #
 # Outputs:
 #   - Registry: ${REGISTRY}/nvidia-tegra-nvgpu:${NVGPU_VERSION}-${KERNEL_VERSION}-talos
-#   - Registry: ${REGISTRY}/custom-installer:${TALOS_VERSION}-${KERNEL_VERSION}  (updated kernel)
+#   - Registry: ${REGISTRY}/custom-installer:${TALOS_VERSION}-${KERNEL_VERSION}  (installer-base + new kernel)
 set -euo pipefail
 source "$(dirname "$0")/common.sh"
 
@@ -187,12 +187,24 @@ info "    Key verified: kernel serial ${KERNEL_KEY_SERIAL} matches keys/signing_
 # ── Step 5: Rebuild custom-installer with the new vmlinuz ──────────────────────
 # This ensures the kernel embedded in the UKI has the SAME signing key as
 # the nvgpu modules. Skipping this step would cause module rejection on boot.
-info "Step 5: Rebuilding custom-installer with new vmlinuz..."
+#
+# Base image is ghcr.io/siderolabs/installer-base, NOT ghcr.io/siderolabs/installer.
+# Since Talos 1.14 the full `installer` image is no longer published: released
+# installers are served by the Image Factory, which cannot take a custom kernel.
+# `installer-base` (rootfs + /usr/bin/installer, no kernel) is still published and
+# is what Talos' own imager uses as the default baseInstaller since 1.11
+# (pkg/imager/profile/input.go, SupportsUnifiedInstaller).
+#
+# The copied vmlinuz.efi is a TRANSPORT artifact only: build-uki.sh extracts it
+# from this image to build custom-imager. The imager's `installer` output re-adds
+# the kernel from its own input (custom-imager's /usr/install/arm64/vmlinuz), so
+# the final installer always carries the same signed kernel as the nvgpu modules.
+info "Step 5: Rebuilding custom-installer (installer-base + new vmlinuz)..."
 INSTALLER_BUILD_DIR=$(mktemp -d)
 trap 'rm -rf "${INSTALLER_BUILD_DIR}"' EXIT
 
 cp "${VMLINUZ_SRC}" "${INSTALLER_BUILD_DIR}/vmlinuz.efi"
-printf 'FROM ghcr.io/siderolabs/installer:%s\nCOPY vmlinuz.efi /usr/install/arm64/vmlinuz.efi\n' \
+printf 'FROM ghcr.io/siderolabs/installer-base:%s\nCOPY vmlinuz.efi /usr/install/arm64/vmlinuz.efi\n' \
   "${TALOS_VERSION}" > "${INSTALLER_BUILD_DIR}/Dockerfile"
 
 docker buildx build \

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -15,7 +15,7 @@ CACHE_REGISTRY="${CACHE_REGISTRY:-}"  # set to ghcr.io/<owner>/build-cache in CI
 
 # ── Talos version ────────────────────────────────────────────────────────────
 # Tracked by Renovate — update-talos.yaml is no longer used (removed).
-TALOS_VERSION="${TALOS_VERSION:-v1.13.10}"
+TALOS_VERSION="${TALOS_VERSION:-v1.14.0}"
 
 # ── siderolabs/pkgs pin — derived from TALOS_VERSION ─────────────────────────
 # Talos records the exact pkgs commit it was built against in its own


### PR DESCRIPTION
Talos 1.14 stopped publishing `ghcr.io/siderolabs/installer` (siderolabs/talos#13138, #13202). Released installers are served by the Image Factory, which is no replacement here: it only accepts *official* extensions by name and has no way to inject a custom kernel — and a custom-signed kernel is exactly what the OE4T modules need.

## Fix

`scripts/build-extensions.sh` now bases `custom-installer` on **`ghcr.io/siderolabs/installer-base`** (still published, in the v1.14.0 "Images" list). That is not a workaround but the upstream default: since Talos 1.11 the imager itself falls back to `installer-base:<version>` as `baseInstaller` (`pkg/imager/profile/input.go`, `SupportsUnifiedInstaller`).

The kernel in the final installer still comes from `custom-imager`: `outInstaller` (`pkg/imager/out.go`) appends an artifacts layer with the kernel from its own `Input.Kernel.Path`. The `vmlinuz.efi` copied into `custom-installer` is only the transport artifact `build-uki.sh` extracts. `ghcr.io/siderolabs/imager` is unaffected, so **`build-uki.sh` and `release.yaml` needed no change**.

Split into two commits: the `installer-base` swap is correct for 1.13.x too and is kept separate from the version bump.

## Validation

**CI**
- [`build-extensions` 33973042871](https://github.com/schwankner/talos-jetson-orin/actions/runs/33973042871) — `FROM ghcr.io/siderolabs/installer-base:v1.14.0@sha256:b48413ee…`, pkgs @ `2f03590` (release-1.14), 415 modules for 6.18.48, signing key verified
- [`release` 33978320343](https://github.com/schwankner/talos-jetson-orin/actions/runs/33978320343) — UKI 609 MB, installer assembled over `baseInstaller`, pushed `custom-installer:v1.14.0-6.18.48-nvgpu5.11.1-drm-noshim`

**Hardware** — in-place `talosctl upgrade` on the Orin NX (10.0.10.38), v1.13.0 → v1.14.0, clean (`post check passed`, node uncordoned):

| | before | after |
|---|---|---|
| Talos / kernel | v1.13.0 / 6.18.24 | **v1.14.0 / 6.18.48** |
| nvgpu extension | 5.11.0-drm-noshim | **5.11.1-drm-noshim-6.18.48** |
| `/dev/dri` | *empty* | **card0, card1, renderD128** |
| `tegra_drm`, `nvhwpm` | *not loaded* | **loaded** |
| dmesg | `tegra_drm: Unknown symbol host1x_syncpt_read (err -22)` | *clean* |
| Ollama | — | `library=CUDA compute=8.7`, 15.3 GiB |

Benchmarks (MAXN, 918 MHz, models 100 % VRAM-resident): **qwen2.5:0.5b 65.0 / 66.0 / 65.9 tok/s** (reference 64.6) and **qwen3:4b 16.4 tok/s** (reference 16.4).

Note the node happened to be running the older 5.11.0 extension, whose `tegra-drm.ko` is not installed at the `kernel/drivers/gpu/drm/tegra/` shadow path (fixed in 5.11.1, `f2ba3b9`), so the GPU was broken beforehand — the upgrade fixed that at the same time.

## Not in this PR

The v1alpha1 fields `.machine.kernel`, `.machine.install` and `.machine.files` are deprecated in 1.14 in favour of `KernelModuleConfig` / `UnattendedInstallConfig` / `EtcFileConfig`, but are "moved out", not removed, and keep working — migrating them is tracked separately.

Also adds BUGS.md Bug 22 (this) and Bug 23 (the `check-talos.yaml` latest-release false positive fixed in a84d22f).